### PR TITLE
add viewBox attribute to svg serializer

### DIFF
--- a/flat/svg.py
+++ b/flat/svg.py
@@ -154,8 +154,8 @@ def serialize(page, compress):
         b'<svg version="1.1" '
             b'xmlns="http://www.w3.org/2000/svg" '
             b'xmlns:xlink="http://www.w3.org/1999/xlink" '
-            b'viewBox="0 0 %s %s" '
-            b'width="%spt" height="%spt">\n'
+            b'width="%spt" height="%spt" '
+            b'viewBox="0 0 %s %s">\n'
         b'<title>%s</title>\n'
         b'%s%s\n'
         b'</svg>') % (

--- a/flat/svg.py
+++ b/flat/svg.py
@@ -154,10 +154,12 @@ def serialize(page, compress):
         b'<svg version="1.1" '
             b'xmlns="http://www.w3.org/2000/svg" '
             b'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            b'viewBox="0 0 %s %s" '
             b'width="%spt" height="%spt">\n'
         b'<title>%s</title>\n'
         b'%s%s\n'
         b'</svg>') % (
+            dump(page.width), dump(page.height),
             dump(page.width), dump(page.height),
             escape(page.title).encode('utf-8'),
             defs, b'\n'.join(item.svg() for item in page.items))


### PR DESCRIPTION
As I understand [the SVG standard](https://www.w3.org/TR/SVG/coords.html#InitialCoordinateSystem), units in SVGs without `viewBox` attributes are interpreted as pixels. Flat exports SVGs without a `viewBox` attribute, which leads to unexpected behavior when using these SVGs with downstream tools. (For example, [AxiDraw's Python library](https://axidraw.com/doc/py_api/#introduction) draws Flat-produced SVGs at three-quarter size, because it interprets Flat's units as pixels and defaults to rendering them at 96dpi.)

This pull request adds a `viewBox` attribute to all SVGs produced with Flat. The `min-x` and `min-y` values of the `viewBox` are both zero, and the width and the height `viewBox` are set to the width and the height of the Flat document. This helps ensure that downstream SVG implementations understand what the units inside of the `svg` tag are actually intended to mean!